### PR TITLE
CRM 엔티티 개발 및 연관관계 설정

### DIFF
--- a/src/main/java/com/brogs/crm/domain/AbstractEntity.java
+++ b/src/main/java/com/brogs/crm/domain/AbstractEntity.java
@@ -1,0 +1,38 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class AbstractEntity {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    protected String createdBy;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt;
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    protected String modifiedBy;
+}

--- a/src/main/java/com/brogs/crm/domain/AgentAccount.java
+++ b/src/main/java/com/brogs/crm/domain/AgentAccount.java
@@ -1,0 +1,46 @@
+package com.brogs.crm.domain;
+
+import com.brogs.crm.domain.constant.AccountRoleType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class AgentAccount extends AbstractEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "agent_account_id")
+    private Long id;
+    private String identifier;
+    private String password;
+    private String extension;
+    private AccountRoleType role;
+    private LocalDateTime lastExpiredAt;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "agentAccount") // 관계의 주인을 명시, 주인에서만 수정 삭제 가능
+    private Set<AgentInfo> agentInfos;
+
+    @Builder
+    public AgentAccount(String identifier,
+                        String password,
+                        AccountRoleType role,
+                        String extension) {
+        //TODO : 예외처리 로직
+        this.identifier = identifier;
+        this.password = password;
+        this.role = AccountRoleType.USER;
+        this.extension = extension;
+        this.lastExpiredAt = LocalDateTime.now();
+        this.agentInfos = new HashSet<>();
+    }
+
+
+}

--- a/src/main/java/com/brogs/crm/domain/AgentInfo.java
+++ b/src/main/java/com/brogs/crm/domain/AgentInfo.java
@@ -1,0 +1,63 @@
+package com.brogs.crm.domain;
+
+import com.brogs.crm.domain.constant.AgentRankType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class AgentInfo extends AbstractEntity{
+
+    @Id @GeneratedValue
+    @Column(name = "agent_info_id")
+    private Long id;
+    private String name;
+    private String email;
+    private String groupName;
+    private String phoneNumber;
+    private String address;
+    private String emailCheckToken;
+    private int age;
+    private boolean expire;
+    private boolean certification;
+    private AgentRankType rank;
+    private LocalDateTime tokenGeneratedAt;
+
+    @Lob @Basic(fetch = FetchType.EAGER)
+    private String profileImage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_account_id")
+    private  AgentAccount agentAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @OneToOne(mappedBy = "agentInfo")
+    private Ticket ticket;
+
+    @Builder
+    public AgentInfo(String name,
+                     String email,
+                     int age,
+                     AgentRankType rank,
+                     String groupName,
+                     String phoneNumber,
+                     String address) {
+        //TODO: 예외처리
+        this.name = name;
+        this.email = email;
+        this.age = age;
+        this.rank = rank;
+        this.groupName = groupName;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.expire = false;
+        this.tokenGeneratedAt = LocalDateTime.now();
+        this.certification = false;
+    }
+
+}

--- a/src/main/java/com/brogs/crm/domain/Alarm.java
+++ b/src/main/java/com/brogs/crm/domain/Alarm.java
@@ -1,0 +1,40 @@
+package com.brogs.crm.domain;
+
+import com.brogs.crm.domain.constant.ReadStatusType;
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Alarm {
+
+    @Id @GeneratedValue
+    @Column(name = "alarm_id")
+    private Long id;
+    private String targetId;
+    private String content;
+    private ReadStatusType readStatus;
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "agent_account_id")
+    private AgentAccount agentAccount;
+
+
+    private Alarm(String targetId, String content, ReadStatusType readStatus) {
+        this.targetId = targetId;
+        this.content = content;
+        this.readStatus = readStatus;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static Alarm of(String targetId,
+                           String content,
+                           ReadStatusType readStatus) {
+        return new Alarm(targetId, content, readStatus);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/Company.java
+++ b/src/main/java/com/brogs/crm/domain/Company.java
@@ -1,0 +1,26 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Company extends AbstractEntity {
+
+    @Id @GeneratedValue
+    private Long id;
+    private String name;
+    private String owner;
+
+    @Builder
+    public Company(String name, String owner) {
+        //TODO: 예외처리
+        this.name = name;
+        this.owner = owner;
+    }
+
+
+}

--- a/src/main/java/com/brogs/crm/domain/Customer.java
+++ b/src/main/java/com/brogs/crm/domain/Customer.java
@@ -1,0 +1,64 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Customer extends AbstractEntity{
+
+    @Id @GeneratedValue
+    @Column(name = "customer_id")
+    private Long id;
+    private String name;
+    private String address;
+    private String memo;
+    private String email;
+    private String phoneNumber;
+    private String facebookId;
+    private String instagramId;
+    private String kakaoTalkId;
+    private boolean emailReception;
+    private boolean smsReception;
+    private boolean callReception;
+    private boolean facebookReception;
+    private boolean instagramReception;
+    private boolean kakaoTalkReception;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_info_id")
+    private AgentInfo agentInfos;
+
+    @JoinTable(
+            name = "customer_hashtag",
+            joinColumns = @JoinColumn(name = "customer_id"),
+            inverseJoinColumns = @JoinColumn(name = "hashtag_id")
+    )
+    @ManyToMany
+    private Set<Hashtag> hashtags;
+
+    @Builder
+    public Customer(String name, String email, String phoneNumber, String facebookId, String instagramId, String kakaoTalkId) {
+        //TODO: 예외처리
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.facebookId = facebookId;
+        this.instagramId = instagramId;
+        this.kakaoTalkId = kakaoTalkId;
+        this.hashtags = new LinkedHashSet<>();
+        defaultReceptionSettings();
+    }
+    public void defaultReceptionSettings() {
+        this.emailReception = true;
+        this.smsReception = true;
+        this.callReception = true;
+        this.facebookReception = true;
+        this.instagramReception = true;
+        this.kakaoTalkReception = true;
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/Forward.java
+++ b/src/main/java/com/brogs/crm/domain/Forward.java
@@ -1,0 +1,43 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Forward extends AbstractEntity {
+
+    @Id @GeneratedValue
+    private Long id;
+    private String ticketId;
+    private String content;
+    private String sender;
+    private String senderGroup;
+    private String receiver;
+    private String receiverGroup;
+
+    private Forward(String ticketId, String content, String sender, String senderGroup, String receiver, String receiverGroup) {
+        this.ticketId = ticketId;
+        this.content = content;
+        this.sender = sender;
+        this.senderGroup = senderGroup;
+        this.receiver = receiver;
+        this.receiverGroup = receiverGroup;
+    }
+
+    public static Forward of(String ticketId,
+                             String content,
+                             String sender,
+                             String senderGroup,
+                             String receiver,
+                             String receiverGroup) {
+        // 정해진 폼대로 보내야하기 때문에 팩토리 메서드 패턴으로 작
+        return new Forward(ticketId, content, sender, senderGroup, receiver, receiverGroup);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/Group.java
+++ b/src/main/java/com/brogs/crm/domain/Group.java
@@ -1,0 +1,36 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Group extends AbstractEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "group_id")
+    private Long id;
+    private String name;
+    private String leader;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id")
+    private Company company;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "group")
+    private Set<AgentInfo> agentInfos;
+
+    @Builder
+    public Group(String name, String leader, Company company) {
+        this.name = name;
+        this.leader = leader;
+        this.company = company;
+        this.agentInfos = new HashSet<>();
+    }
+
+
+}

--- a/src/main/java/com/brogs/crm/domain/Hashtag.java
+++ b/src/main/java/com/brogs/crm/domain/Hashtag.java
@@ -1,0 +1,26 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Hashtag {
+
+    @Id @GeneratedValue
+    @Column(name = "hashtag_id")
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String title;
+
+    private Hashtag(String title) {
+        this.title = title;
+    }
+
+    public static Hashtag of(String title){
+        return new Hashtag(title);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/Macro.java
+++ b/src/main/java/com/brogs/crm/domain/Macro.java
@@ -1,0 +1,28 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Macro {
+
+    @Id @GeneratedValue
+    @Column(name = "macro_id")
+    private Long id;
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_account_id")
+    private AgentAccount agentAccount;
+
+    private Macro(String content) {
+        this.content = content;
+    }
+
+    public static Macro of(String content) {
+        return new Macro(content);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/Manual.java
+++ b/src/main/java/com/brogs/crm/domain/Manual.java
@@ -1,0 +1,37 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Manual extends AbstractEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "manual_id")
+    private Long id;
+    private String title;
+    private String content;
+
+    @JoinTable(
+            name = "manual_hashtag",
+            joinColumns = @JoinColumn(name = "manual_id"),
+            inverseJoinColumns = @JoinColumn(name = "hashtag_id")
+    )
+    @ManyToMany
+    private Set<Hashtag> hashtags = new LinkedHashSet<>();
+
+    private Manual(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public static Manual of(String title, String content){
+        return new Manual(title, content);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/Message.java
+++ b/src/main/java/com/brogs/crm/domain/Message.java
@@ -1,0 +1,49 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Message {
+
+    @Id @GeneratedValue
+    private Long id;
+    private String sender;
+    private String content;
+    private String channel;
+    private boolean read;
+    private boolean innerMemo;
+    private LocalDateTime sendTime;
+
+    @Lob @Basic(fetch = FetchType.EAGER)
+    private String attachment;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ticket_id")
+    private Ticket ticket;
+
+    private Message(String sender, String content, String attachment, String channel, boolean innerMemo, LocalDateTime sendTime) {
+        this.sender = sender;
+        this.content = content;
+        this.attachment = attachment;
+        this.channel = channel;
+        this.read = false;
+        this.innerMemo = innerMemo;
+        this.sendTime = sendTime;
+    }
+
+    public static Message of(String sender,
+                             String content,
+                             String attachment,
+                             String channel,
+                             boolean innerMemo,
+                             LocalDateTime sendTime) {
+        return new Message(sender, content, attachment, channel, innerMemo, sendTime);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/Ticket.java
+++ b/src/main/java/com/brogs/crm/domain/Ticket.java
@@ -1,0 +1,55 @@
+package com.brogs.crm.domain;
+
+import com.brogs.crm.domain.constant.TicketPriorityType;
+import com.brogs.crm.domain.constant.TicketStatusType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class Ticket extends AbstractEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "ticket_id")
+    private Long id;
+    private String title;
+    private String memo;
+    private String referenceUrl;
+    private int score;
+    private TicketStatusType status;
+    private TicketPriorityType priority;
+
+
+    @ManyToOne
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_info_id")
+    private AgentInfo agentInfo;
+
+//    @OneToMany(mappedBy = "ticket")
+//    private List<Message> messages;
+//    티켓을 조회하고 -> 여러티켓에서 -> 여러메세지를 조회할 일이 있으면 사용하기 좋다
+
+    @JoinTable(
+            name = "ticket_hashtag",
+            joinColumns = @JoinColumn(name = "ticket_id"),
+            inverseJoinColumns = @JoinColumn(name = "hashtag_id")
+    )
+    @ManyToMany
+    private Set<Hashtag> hashtags = new LinkedHashSet<>();
+
+    @Builder
+    public Ticket(String title, String memo) {
+        this.title = title;
+        this.memo = memo;
+        this.priority = TicketPriorityType.MEDIUM;
+        this.status = TicketStatusType.PROCESSING;
+    }
+
+}

--- a/src/main/java/com/brogs/crm/domain/TicketSummary.java
+++ b/src/main/java/com/brogs/crm/domain/TicketSummary.java
@@ -1,0 +1,44 @@
+package com.brogs.crm.domain;
+
+import com.brogs.crm.domain.constant.TicketPriorityType;
+import com.brogs.crm.domain.constant.TicketStatusType;
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class TicketSummary extends AbstractEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "ticket_summary_id")
+    private Long id;
+    private String title;
+    private int score;
+    private TicketStatusType status;
+    private TicketPriorityType priority;
+
+    @ToString.Exclude
+    //@OrderBy("createdAt DESC")
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+    private Set<TicketSummaryComment> articleComments = new LinkedHashSet<>();
+
+    private TicketSummary(String title, TicketPriorityType priority, TicketStatusType status, int score) {
+        this.title = title;
+        this.priority = priority;
+        this.status = status;
+        this.score = score;
+    }
+
+    public static TicketSummary of(String title,
+                                   TicketPriorityType priority,
+                                   TicketStatusType status,
+                                   int score) {
+        return new TicketSummary(title, priority, status, score);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/TicketSummaryComment.java
+++ b/src/main/java/com/brogs/crm/domain/TicketSummaryComment.java
@@ -1,0 +1,36 @@
+package com.brogs.crm.domain;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Entity @Getter
+public class TicketSummaryComment extends AbstractEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "ticket_summary_id")
+    private Long id;
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_info_id")
+    private AgentInfo agentInfo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_summary_id")
+    private TicketSummary ticketSummary;
+
+    private TicketSummaryComment(String content, AgentInfo agentInfo, TicketSummary ticketSummary) {
+        this.content = content;
+        this.agentInfo = agentInfo;
+        this.ticketSummary = ticketSummary;
+    }
+
+    public static TicketSummaryComment of(String content,
+                                   AgentInfo agentInfo,
+                                   TicketSummary ticketSummary) {
+        return new TicketSummaryComment(content, agentInfo, ticketSummary);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/constant/AccountRoleType.java
+++ b/src/main/java/com/brogs/crm/domain/constant/AccountRoleType.java
@@ -1,0 +1,5 @@
+package com.brogs.crm.domain.constant;
+
+public enum AccountRoleType {
+        USER, MANAGER, ADMIN;
+    }

--- a/src/main/java/com/brogs/crm/domain/constant/AgentRankType.java
+++ b/src/main/java/com/brogs/crm/domain/constant/AgentRankType.java
@@ -1,0 +1,13 @@
+package com.brogs.crm.domain.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AgentRankType {
+    // example
+    MANAGER("팀장"), SUPERVISOR("주임"), STAFF("사원");
+
+    private final String description;
+}

--- a/src/main/java/com/brogs/crm/domain/constant/ReadStatusType.java
+++ b/src/main/java/com/brogs/crm/domain/constant/ReadStatusType.java
@@ -1,0 +1,12 @@
+package com.brogs.crm.domain.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReadStatusType {
+    READ("읽음", true), UNREAD("읽지않음", false);
+    private final String description;
+    private final boolean read;
+}

--- a/src/main/java/com/brogs/crm/domain/constant/TicketPriorityType.java
+++ b/src/main/java/com/brogs/crm/domain/constant/TicketPriorityType.java
@@ -1,0 +1,13 @@
+package com.brogs.crm.domain.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TicketPriorityType {
+
+    HIGH("높음"), MEDIUM("보통"), LOW("낮음"), URGENT("긴급");
+
+    private final String description;
+}

--- a/src/main/java/com/brogs/crm/domain/constant/TicketStatusType.java
+++ b/src/main/java/com/brogs/crm/domain/constant/TicketStatusType.java
@@ -1,0 +1,13 @@
+package com.brogs.crm.domain.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TicketStatusType {
+
+    FINISHED("처리완료"), HOLD("보류"), PROCESSING("처리중"), PENDING("미해결");
+
+    private final String description;
+}


### PR DESCRIPTION
CRM 엔티티 개발 및 연관관계를 설정하였다
기본적으로 역참조를 사용하지않고 FK를 연관관계의 주인(다)에 두는 방향으로 RDBMS와 패러다임을 맞추었다.
하지만 편의상 필요한 부분에는 역참조(OneToMany)를 허용하였지만 필요없다고 판단될 시 삭제 할 것이다.
ERD가 변경되면 변경될 수 있다.

This closes #14 