### PR TITLE
회원가입, 로그인 및 Jwt 인증 프로세스 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/app.properties
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,31 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // mapstruct, lombok
+    implementation "org.mapstruct:mapstruct:1.5.3.Final"
+    testImplementation 'junit:junit:4.13.1'
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
+    annotationProcessor "org.mapstruct:mapstruct-processor:1.5.3.Final"
+    annotationProcessor "org.projectlombok:lombok:"
+
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
+    compileOnly 'org.projectlombok:lombok'
+
+
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/brogs/crm/common/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/brogs/crm/common/exception/InvalidCredentialsException.java
@@ -1,0 +1,23 @@
+package com.brogs.crm.common.exception;
+
+
+import com.brogs.crm.common.response.ErrorCode;
+
+public class InvalidCredentialsException extends BaseException {
+
+    public InvalidCredentialsException() {
+        super(ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    public InvalidCredentialsException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidCredentialsException(String errorMsg) {
+        super(errorMsg, ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    public InvalidCredentialsException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/agentaccount/AccountCommand.java
+++ b/src/main/java/com/brogs/crm/domain/agentaccount/AccountCommand.java
@@ -1,0 +1,32 @@
+package com.brogs.crm.domain.agentaccount;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+public class AccountCommand {
+
+    @Getter
+    @Builder
+    @ToString
+    public static class RegisterAccount {
+        private final String identifier;
+        private final String password;
+
+        public AgentAccount toEntity(String encodedPassword) {
+            return AgentAccount.builder()
+                    .identifier(identifier)
+                    .password(encodedPassword)
+                    .build();
+        }
+
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class login {
+        private final String identifier;
+        private final String password;
+    }
+}

--- a/src/main/java/com/brogs/crm/domain/agentaccount/AccountDao.java
+++ b/src/main/java/com/brogs/crm/domain/agentaccount/AccountDao.java
@@ -1,0 +1,11 @@
+package com.brogs.crm.domain.agentaccount;
+
+import java.util.Optional;
+
+public interface AccountDao {
+    Optional<AgentAccount> findByIdentifier(String identifier);
+
+    AgentAccount save(AgentAccount agentAccount);
+
+    AgentAccount getByIdentifier(String identifier);
+}

--- a/src/main/java/com/brogs/crm/domain/agentaccount/AccountInfo.java
+++ b/src/main/java/com/brogs/crm/domain/agentaccount/AccountInfo.java
@@ -3,8 +3,32 @@ package com.brogs.crm.domain.agentaccount;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
 
 public class AccountInfo {
+
+    @Getter
+    @Builder
+    @ToString
+    public static class Main {
+        private String identifier;
+        private String password;
+        private String extension;
+        private Set<String> authorities;
+
+        public static Main from(AgentAccount entity) {
+            return  Main.builder()
+                    .identifier(entity.getIdentifier())
+                    .password(entity.getPassword())
+                    .extension(entity.getExtension())
+                    .authorities(Set.of(entity.getRole()))
+                    .build();
+        }
+    }
 
     @Getter
     @Builder
@@ -14,9 +38,12 @@ public class AccountInfo {
         private String password;
         private String role;
 
-//        public AccountInfo.Register fromEntity(AgentAccount agentAccount) {
-//            return agentAccount
-//
-//        }
+        public static AccountInfo.Register from(AgentAccount agentAccount) {
+            return Register.builder()
+                    .identifier(agentAccount.getIdentifier())
+                    .password(agentAccount.getPassword())
+                    .role(agentAccount.getRole().toString())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/brogs/crm/domain/agentaccount/AccountService.java
+++ b/src/main/java/com/brogs/crm/domain/agentaccount/AccountService.java
@@ -1,0 +1,79 @@
+package com.brogs.crm.domain.agentaccount;
+
+import com.brogs.crm.common.AccountPrincipal;
+import com.brogs.crm.common.exception.InvalidParamException;
+import com.brogs.crm.common.response.ErrorCode;
+import com.brogs.crm.infra.agentaccount.AccountRepository;
+import com.brogs.crm.security.jwt.JwtTokenProvider;
+import com.brogs.crm.security.jwt.JwtTokens;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AccountService implements UserDetailsService {
+
+    private final AccountDao accountDao;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider tokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public AccountInfo.Register register(AccountCommand.RegisterAccount registerAccount) {
+        accountDao.findByIdentifier(registerAccount.getIdentifier()).ifPresent(e -> {
+            throw new InvalidParamException(ErrorCode.ALREADY_EXISTENT_ACCOUNT);
+        });
+
+        AgentAccount initAgentAccount = registerAccount.toEntity(passwordEncoder.encode(registerAccount.getPassword()));
+
+        return AccountInfo.Register.from(accountDao.save(initAgentAccount));
+    }
+
+    @Transactional
+    public JwtTokens login(AccountCommand.login login) {
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(login.getIdentifier(), login.getPassword());
+
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        JwtTokens jwtTokens = tokenProvider.createJwtTokens(authentication);
+
+        return jwtTokens;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String identifier) throws UsernameNotFoundException {
+        return accountDao.findByIdentifier(identifier)
+                .map(AccountInfo.Main::from)
+                .map(AccountPrincipal::from)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+    }
+
+    public JwtTokens refreshAccessToken(String subject, String refreshToken) {
+        String identifier = tokenProvider.getSubject(refreshToken);
+        log.info("identifier={}",identifier);
+
+        if (!subject.equals(identifier)) {
+            throw new BadCredentialsException("올바른 토큰이 아닙니다.");
+        }
+
+        return tokenProvider.renewJwtTokens(refreshToken);
+    }
+}

--- a/src/main/java/com/brogs/crm/infra/agentaccount/AccountDaoImpl.java
+++ b/src/main/java/com/brogs/crm/infra/agentaccount/AccountDaoImpl.java
@@ -1,0 +1,20 @@
+package com.brogs.crm.infra.agentaccount;
+
+import com.brogs.crm.domain.agentaccount.AccountDao;
+import com.brogs.crm.domain.agentaccount.AgentAccount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class AccountDaoImpl implements AccountDao {
+
+    private final AccountRepository accountRepository;
+
+    @Override public Optional<AgentAccount> findByIdentifier(String identifier) { return accountRepository.findByIdentifier(identifier);}
+    @Override public AgentAccount save(AgentAccount agentAccount) { return accountRepository.save(agentAccount);}
+
+    @Override public AgentAccount getByIdentifier(String identifier) { return accountRepository.getReferenceByIdentifier(identifier); }
+}

--- a/src/main/java/com/brogs/crm/infra/agentaccount/AccountRepository.java
+++ b/src/main/java/com/brogs/crm/infra/agentaccount/AccountRepository.java
@@ -1,0 +1,16 @@
+package com.brogs.crm.infra.agentaccount;
+
+import com.brogs.crm.domain.agentaccount.AgentAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AccountRepository extends JpaRepository<AgentAccount, Long> {
+
+    Optional<AgentAccount> findByIdentifier(String identifier);
+
+    AgentAccount save(AgentAccount agentAccount);
+
+    AgentAccount getReferenceByIdentifier(String identifier);
+
+}

--- a/src/main/java/com/brogs/crm/interfaces/controller/agentaccount/AccountController.java
+++ b/src/main/java/com/brogs/crm/interfaces/controller/agentaccount/AccountController.java
@@ -1,0 +1,46 @@
+package com.brogs.crm.interfaces.controller.agentaccount;
+
+import com.brogs.crm.common.response.CommonResponse;
+import com.brogs.crm.domain.agentaccount.AccountInfo;
+import com.brogs.crm.domain.agentaccount.AccountService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/account")
+public class AccountController {
+
+    private final AccountService accountService;
+    private final AccountDtoMapper accountDtoMapper;
+
+    @PostMapping("/join")
+    public CommonResponse signUp(@RequestBody AccountDto.SignUpReq request) {
+
+        var registerInfo = accountService.register(accountDtoMapper.of(request));
+        var response = accountDtoMapper.of(registerInfo);
+        return CommonResponse.success(response);
+    }
+
+    @PostMapping("/login")
+    public CommonResponse signIn(@RequestBody AccountDto.SignInReq request) {
+
+        var tokens = accountService.login(accountDtoMapper.of(request));
+        return CommonResponse.success(tokens);
+    }
+
+    @GetMapping("/refresh-token")
+    public CommonResponse refreshToken(@RequestAttribute String refreshToken,
+                                       @RequestAttribute String subject) {
+
+        var renewTokens = accountService.refreshAccessToken(subject, refreshToken);
+        return CommonResponse.success(renewTokens);
+    }
+
+}

--- a/src/main/java/com/brogs/crm/interfaces/controller/agentaccount/AccountDto.java
+++ b/src/main/java/com/brogs/crm/interfaces/controller/agentaccount/AccountDto.java
@@ -1,0 +1,30 @@
+package com.brogs.crm.interfaces.controller.agentaccount;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+public class AccountDto {
+
+    @Getter
+    @Setter
+    public static class SignUpReq {
+        private String identifier;
+        private String password;
+    }
+
+    @Getter
+    @Setter
+    public static class SignUpRes {
+        private String identifier;
+        private String role;
+    }
+
+    @Getter
+    @Setter
+    public static class SignInReq {
+        private String identifier;
+        private String password;
+    }
+
+}

--- a/src/main/java/com/brogs/crm/interfaces/controller/agentaccount/AccountDtoMapper.java
+++ b/src/main/java/com/brogs/crm/interfaces/controller/agentaccount/AccountDtoMapper.java
@@ -1,0 +1,20 @@
+package com.brogs.crm.interfaces.controller.agentaccount;
+
+import com.brogs.crm.domain.agentaccount.AccountCommand;
+import com.brogs.crm.domain.agentaccount.AccountInfo;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface AccountDtoMapper {
+
+    AccountCommand.RegisterAccount of(AccountDto.SignUpReq request);
+    AccountCommand.login of(AccountDto.SignInReq request);
+    AccountDto.SignUpRes of(AccountInfo.Register result);
+
+}

--- a/src/main/java/com/brogs/crm/security/SecurityConfig.java
+++ b/src/main/java/com/brogs/crm/security/SecurityConfig.java
@@ -1,0 +1,68 @@
+package com.brogs.crm.security;
+
+import com.brogs.crm.security.jwt.JwtSecurityConfig;
+import com.brogs.crm.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtTokenProvider tokenProvider;
+    private final CorsFilter corsFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf().disable()
+                .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling()
+                // enable h2-console
+                .and()
+                .headers()
+                .frameOptions()
+                .sameOrigin()
+
+                // 세션을 사용하지 않기 때문에 STATELESS 로 설정
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+
+                .authorizeHttpRequests()
+                    .requestMatchers(
+                                "/api/v1/account/join",
+                                "/api/v1/account/login"
+                    ).permitAll()
+                .anyRequest().authenticated() //이게 있어야 인증 진행한다
+
+                .and()
+                .apply(new JwtSecurityConfig(tokenProvider))
+
+                .and()
+                .build();
+
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers("/h2-console/**"
+                , "/favicon.ico"
+                , "/error");
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/brogs/crm/security/jwt/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/brogs/crm/security/jwt/JwtExceptionHandlerFilter.java
@@ -1,0 +1,36 @@
+package com.brogs.crm.security.jwt;
+
+import com.brogs.crm.common.exception.InvalidCredentialsException;
+import com.brogs.crm.common.response.CommonResponse;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filter) throws ServletException, IOException {
+
+        try{
+            filter.doFilter(request, response);
+        } catch (InvalidCredentialsException e) {
+            ObjectMapper objectMapper = new ObjectMapper();
+
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter()
+                    .write(objectMapper.writeValueAsString(
+                            CommonResponse.fail(e.getMessage(), e.getErrorCode().toString())
+                            )
+                    );
+        }
+    }
+}

--- a/src/main/java/com/brogs/crm/security/jwt/JwtFilter.java
+++ b/src/main/java/com/brogs/crm/security/jwt/JwtFilter.java
@@ -1,0 +1,95 @@
+package com.brogs.crm.security.jwt;
+
+import com.brogs.crm.common.exception.InvalidCredentialsException;
+import com.brogs.crm.common.response.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.springframework.util.StringUtils.*;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
+    private static final String REFRESH_TOKEN_URI = "refresh-token";
+    private static final String BEARER = "Bearer ";
+    public final JwtTokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = resolveToken(request, AUTHORIZATION_HEADER);
+
+        try {
+            if (isValidToken(accessToken)) {
+                Authentication authentication = tokenProvider.getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.info("Security Context 에 {} 인증 정보를 저장했습니다", authentication.getName());
+            }
+
+        } catch(ExpiredJwtException ex) {
+            String requestUri = request.getRequestURI();
+            String refreshToken = resolveToken(request, REFRESH_TOKEN_HEADER);
+            log.info("토큰 갱신 요청으로 인해 토큰 검증을 시작합니다. requestUri={}", requestUri);
+
+            try {
+                if (isValidToken(refreshToken) && requestUri.contains(REFRESH_TOKEN_URI)) {
+                    log.info("리프레시 요청");
+                    allowForRefreshToken(refreshToken, ex.getClaims().getSubject(), request);
+                }
+            } catch (ExpiredJwtException e) {
+                log.info("리프레시 토큰 만료");
+                throw new InvalidCredentialsException("다시 로그인 해 주세요.", ErrorCode.EXPIRED_REFRESH_TOKEN);
+            }
+        }
+
+        log.info("next filter start");
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request, String header) {
+        String rawToken = request.getHeader(header);
+        if (StringUtils.hasText(rawToken)) { return getBearerToken(rawToken); }
+        if (header == AUTHORIZATION_HEADER) { return null; }
+
+        throw new InvalidCredentialsException("잘못된 타입이거나, 토큰이 없습니다.", ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    private String getBearerToken(String bearerToken) {
+        if (!bearerToken.startsWith(BEARER)) {
+            throw new InvalidCredentialsException("잘못된 타입이거나, 토큰이 없습니다.", ErrorCode.INVALID_CREDENTIALS);
+        }
+        return bearerToken.substring(7);
+    }
+
+    private boolean isValidToken(String jwtToken) {
+        return  StringUtils.hasText(jwtToken) && tokenProvider.validateToken(jwtToken);
+    }
+
+    private void allowForRefreshToken(String refreshToken, String subject, HttpServletRequest request) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(null, null, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        request.setAttribute("refreshToken", refreshToken);
+        request.setAttribute("subject", subject);
+    }
+
+
+}

--- a/src/main/java/com/brogs/crm/security/jwt/JwtSecurityConfig.java
+++ b/src/main/java/com/brogs/crm/security/jwt/JwtSecurityConfig.java
@@ -1,0 +1,22 @@
+package com.brogs.crm.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final JwtTokenProvider tokenProvider;
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http.addFilterBefore(
+                    new JwtFilter(tokenProvider),
+                    UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(
+                    new JwtExceptionHandlerFilter(),
+                    JwtFilter.class);
+    }
+}

--- a/src/main/java/com/brogs/crm/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/brogs/crm/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,148 @@
+package com.brogs.crm.security.jwt;
+
+import com.brogs.crm.common.AccountPrincipal;
+import com.brogs.crm.common.exception.InvalidCredentialsException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider implements InitializingBean {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private final String secret;
+    private final long tokenValidityInSeconds;
+    private final long refreshValidityInSeconds;
+    private Key key;
+
+    public JwtTokenProvider(@Value("${JWT_SECRET_KEY}") String secret,
+                            @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds,
+                            @Value("${jwt.refresh-validity-in-seconds}") long refreshValidityInSeconds) {
+        this.secret = secret;
+        this.tokenValidityInSeconds = tokenValidityInSeconds;
+        this.refreshValidityInSeconds = refreshValidityInSeconds;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * authentication 객체를 이용해 최초 로그인시 발급하는 토큰 AccessToken, RefreshToken
+     */
+    public JwtTokens createJwtTokens(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date accessTokenExpirationDate = getAccessTokenExpirationDate(getCurrentTime());
+        String accessToken = createToken(
+                authentication.getName(),
+                authorities,
+                accessTokenExpirationDate);
+
+        Date refreshTokenExpirationDate = getRefreshTokenExpirationDate(getCurrentTime());
+        String refreshToken = createToken(
+                authentication.getName(),
+                authorities,
+                refreshTokenExpirationDate);
+
+        return JwtTokens.of(accessToken, refreshToken, accessTokenExpirationDate, refreshTokenExpirationDate);
+    }
+
+    /**
+     * AccessToken 은 과 만료된 AccessToken 과 RefreshToken 으로 인해 갱신됨
+     */
+    public JwtTokens renewJwtTokens(String refreshToken) {
+        Claims claims = parseClaims(refreshToken);
+        Date accessTokenExpirationDate = getAccessTokenExpirationDate(getCurrentTime());
+        String renewedAccessToken = createToken(
+                claims.getSubject(),
+                claims.get(AUTHORITIES_KEY).toString(),
+                accessTokenExpirationDate);
+
+        Date refreshTokenExpirationDate = getRefreshTokenExpirationDate(getCurrentTime());
+        String renewedRefreshToken = createToken(
+                claims.getSubject(),
+                claims.get(AUTHORITIES_KEY).toString(),
+                refreshTokenExpirationDate);
+
+        return JwtTokens.of(renewedAccessToken, renewedRefreshToken, accessTokenExpirationDate, refreshTokenExpirationDate);
+    }
+
+    /**
+     * AccessToken 을 파싱해서 SecurityContext 에 저장할 Authentication 객체 생성 (세션 관리 필요없음)
+     */
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toSet());
+        AccountPrincipal accountPrincipal = new AccountPrincipal(claims.getSubject(), null, authorities);
+
+        return new UsernamePasswordAuthenticationToken(accountPrincipal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException | SignatureException ex) {
+            throw new InvalidCredentialsException();
+        }
+    }
+
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    /**
+     * TokenProvider 내부 메서드
+     */
+    private String createToken(String username, String authorities, Date expirationDate) {
+        return Jwts.builder()
+                .setSubject(username)
+                .claim(AUTHORITIES_KEY, authorities)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .setExpiration(expirationDate)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        log.info("parse Token");
+        Claims claim = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claim;
+    }
+
+    private long getCurrentTime() {
+        return new Date().getTime();
+    }
+
+    private Date getAccessTokenExpirationDate(long now) {
+        return new Date(now + tokenValidityInSeconds);
+    }
+
+    private Date getRefreshTokenExpirationDate(long now) {
+        return new Date(now + refreshValidityInSeconds);
+    }
+}

--- a/src/main/java/com/brogs/crm/security/jwt/JwtTokens.java
+++ b/src/main/java/com/brogs/crm/security/jwt/JwtTokens.java
@@ -1,0 +1,29 @@
+package com.brogs.crm.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+public class JwtTokens {
+    private String AccessToken;
+    private String RefreshToken;
+    private Date AccessTokenExpiredAt;
+    private Date RefreshTokenExpiredAt;
+
+    private JwtTokens(String accessToken, String refreshToken, Date accessTokenExpiredAt, Date refreshTokenExpiredAt) {
+        AccessToken = accessToken;
+        RefreshToken = refreshToken;
+        AccessTokenExpiredAt = accessTokenExpiredAt;
+        RefreshTokenExpiredAt = refreshTokenExpiredAt;
+    }
+
+    public static JwtTokens of(String accessToken,
+                               String refreshToken,
+                               Date accessTokenExpiredAt,
+                               Date refreshTokenExpiredAt){
+
+        return new JwtTokens(accessToken, refreshToken, accessTokenExpiredAt, refreshTokenExpiredAt);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url:  jdbc:h2:tcp://localhost/~/crm-h2
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate.format_sql: true
+
+logging:
+  level:
+    #org.hibernate.SQL: debug
+    org.hibernate.type: trace
+
+jwt:
+  header: Authorization
+  token-validity-in-seconds: 15000
+  refresh-validity-in-seconds: 100000

--- a/src/test/java/com/brogs/crm/controller/AccountControllerTest.java
+++ b/src/test/java/com/brogs/crm/controller/AccountControllerTest.java
@@ -1,0 +1,159 @@
+package com.brogs.crm.controller;
+
+import com.brogs.crm.common.exception.InvalidParamException;
+import com.brogs.crm.common.response.ErrorCode;
+import com.brogs.crm.domain.agentaccount.*;
+import com.brogs.crm.interfaces.controller.agentaccount.AccountController;
+import com.brogs.crm.interfaces.controller.agentaccount.AccountDto;
+import com.brogs.crm.common.AccountPrincipal;
+import com.brogs.crm.interfaces.controller.agentaccount.AccountDtoMapper;
+import com.brogs.crm.security.SecurityConfig;
+import com.brogs.crm.security.jwt.JwtTokens;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * BDD 시나리오 + API 스펙 검증
+ */
+@DisplayName("계정 컨트롤러 - 로그인, 회원가입")
+@WebMvcTest(AccountController.class)
+class AccountControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean AccountDtoMapper accountDtoMapper;
+    @MockBean AccountService accountService;
+
+    @DisplayName("[POST] 회원가입 요청 성공")
+    @Test
+    public void AccountInfo_RequestingSignUp_Success() throws Exception {
+        // Given
+        given(accountService.register(mock(AccountCommand.RegisterAccount.class))).willReturn(RegisterAccountInfo());
+        given(accountDtoMapper.of((AccountInfo.Register) any())).willReturn(SignUpRes());
+
+        // When
+        mvc.perform(post("/api/v1/account/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signUpRequest())))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("result").value("SUCCESS"))
+                .andExpect(jsonPath("data.identifier").exists())
+                .andExpect(jsonPath("data.role").exists());
+
+        // Then
+        then(accountService).should().register(any());
+    }
+
+    @DisplayName("[POST] 회원가입 요청 실패 - 동일한 계정이 존재")
+    @Test
+    public void AccountInfo_RequestingSignUp_Fail() throws Exception {
+        //Given
+        given(accountService.register(existentAccount())).willThrow(new InvalidParamException(ErrorCode.ALREADY_EXISTENT_ACCOUNT));
+        //given(accountDtoMapper.of((AccountInfo.Register) any())).willReturn(SignUpRes());
+
+        //When
+        mvc.perform(post("/api/v1/account/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signUpRequest())))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //Then
+        //TODO :: 응답실패 컨트롤러로 보내야함
+        //then(accountDtoMapper).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[POST] 로그인 요청 성공")
+    @Test
+    public void AccountInfo_RequestingSignIn_Success() throws Exception{
+        //Given
+        given(accountService.login(mock(AccountCommand.login.class))).willReturn(mock(JwtTokens.class));
+
+        //When
+        mvc.perform(post("/api/v1/account/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signInRequest())))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //Then
+        then(accountService).should().login(mock(AccountCommand.login.class));
+    }
+
+    @DisplayName("[POST] 로그인 요청 실패 - 잘못된 계정정보")
+    @Test
+    public void AccountInfo_RequestingSignIn_Fail() throws Exception{
+        //Given
+        given(accountService.register(any())).willThrow(new InvalidParamException("아이디나 비밀번호를 다시 확인해주세요."));
+
+        //When
+        mvc.perform(post("/api/v1/account/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signInRequest())))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //Then
+//        then(accountService).shouldHaveNoMoreInteractions();
+    }
+
+    /**
+     * 회원가입 성공 테스트를 위한 객체
+     */
+    private AccountDto.SignUpRes SignUpRes() {
+        AccountDto.SignUpRes signUpRes = new AccountDto.SignUpRes();
+        signUpRes.setIdentifier("test");
+        signUpRes.setRole("USER");
+        return signUpRes;
+    }
+    private AccountInfo.Register RegisterAccountInfo() {
+        return AccountInfo.Register.from(AgentAccount.builder()
+                .identifier("test")
+                .password("test")
+                .role(AgentAccount.AccountRoleType.USER)
+                .build());
+    }
+
+    /**
+     * 회원가입 실패 테스트를 위한 객체 - 이미 존재하는 계정
+     */
+    private AccountCommand.RegisterAccount existentAccount() {
+        return AccountCommand.RegisterAccount
+                .builder()
+                .identifier("existentAccount")
+                .password("secret")
+                .build();
+    }
+
+
+    private AccountDto.SignInReq signInRequest() {
+        AccountDto.SignInReq signIn = new AccountDto.SignInReq();
+        signIn.setIdentifier("test1234");
+        signIn.setPassword("test1234!");
+        return signIn;
+    }
+
+    private AccountDto.SignUpReq signUpRequest() {
+        AccountDto.SignUpReq signUp = new AccountDto.SignUpReq();
+        signUp.setIdentifier("test");
+        signUp.setPassword("test");
+        return signUp;
+    }
+}

--- a/src/test/java/com/brogs/crm/service/AccountServiceTest.java
+++ b/src/test/java/com/brogs/crm/service/AccountServiceTest.java
@@ -1,0 +1,37 @@
+package com.brogs.crm.service;
+
+import com.brogs.crm.domain.agentaccount.AccountDao;
+import com.brogs.crm.domain.agentaccount.AccountService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("비즈니스 로직 - 계정")
+@ExtendWith(MockitoExtension.class)
+class AccountServiceTest {
+
+    // mock 객체를 해당 객체에 주입할 수 있다. System Under Test
+    @InjectMocks
+    private AccountService sut;
+
+    @Mock
+    private AccountDao accountDao;
+
+    @DisplayName("로그인 성공 - Optional 객체 반환")
+    @Test
+    public void ExistentAccount_SignIn_ReturnOptionalAccount() {
+        // Given
+        String username = "";
+        given(accountDao.findByIdentifier(username)).willReturn(Optional.empty());
+
+        // When
+//        sut.login();
+    }
+}


### PR DESCRIPTION
예외처리는 JWT예외처리 필터를 커스터마이징 해서 적용했습니다.
기본적으로 JWT는 parsing 시 아래와 같은 예외를 발생시킵니다.

MalformedJwtException
UnsupportedJwtException
IllegalArgumentException
SignatureException
ExpiredJwtException
전부 Jwt관련 예외기 때문에 파싱시 예외를 따로 처리하는 것 보다,
커스텀된 예외를 만들어 일괄적으로 처리하는게 좋다고 판단하였습니다.

그래서 InvalidCredentialsException예외를 커스텀해 같은 원래 응답하는 양식으로 뿌리기로 했습니다.

This closes #16.