### PR TITLE
Reponse 형식 및 Exception 처리 개발

### DIFF
--- a/src/main/java/com/brogs/crm/common/exception/BaseException.java
+++ b/src/main/java/com/brogs/crm/common/exception/BaseException.java
@@ -1,0 +1,35 @@
+package com.brogs.crm.common.exception;
+
+import com.brogs.crm.common.response.ErrorCode;
+import lombok.Getter;
+
+/**
+ * BaseException 또는 BaseException 을 확장한 Exception 은
+ * 서비스 운영에서 예상이 가능한 Exception 을 표현한다.
+ *
+ * 그렇기 때문에 http status: 200 이면서 result: FAIL 을 표현하고
+ * 특정 ErrorCode 만 alert 를 포함한 모니터링 대상으로 한다.
+ */
+@Getter
+public class BaseException extends RuntimeException{
+
+    private ErrorCode errorCode;
+
+    public BaseException() {
+    }
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getErrorMsg());
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(String message, ErrorCode errorCode, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/brogs/crm/common/exception/InvalidParamException.java
+++ b/src/main/java/com/brogs/crm/common/exception/InvalidParamException.java
@@ -1,0 +1,23 @@
+package com.brogs.crm.common.exception;
+
+
+import com.brogs.crm.common.response.ErrorCode;
+
+public class InvalidParamException extends BaseException {
+
+    public InvalidParamException() {
+        super(ErrorCode.COMMON_INVALID_PARAMETER);
+    }
+
+    public InvalidParamException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidParamException(String errorMsg) {
+        super(errorMsg, ErrorCode.COMMON_INVALID_PARAMETER);
+    }
+
+    public InvalidParamException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/brogs/crm/common/response/CommonControllerAdvice.java
+++ b/src/main/java/com/brogs/crm/common/response/CommonControllerAdvice.java
@@ -1,0 +1,68 @@
+package com.brogs.crm.common.response;
+
+import com.brogs.crm.common.exception.BaseException;
+import com.brogs.crm.common.interceptor.CommonHttpRequestInterceptor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 스프링에서 나가기 전에 익셉션을 최종적으로 처리
+ */
+@Slf4j
+@ControllerAdvice
+public class CommonControllerAdvice {
+
+    private static final List<ErrorCode> SPECIFIC_ALERT_TARGET_ERROR_CODE_LIST = new ArrayList<>();
+
+    /**
+     * http status: 500 AND result: FAIL
+     * 시스템 예외 상황. 집중 모니터링 대상
+     *
+     * @param e
+     * @return
+     */
+    @ResponseBody
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(value = Exception.class)
+    public CommonResponse onException(Exception e) {
+        String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+        log.error("eventId = {} ", eventId, e);
+        return CommonResponse.fail(ErrorCode.COMMON_SYSTEM_ERROR);
+    }
+
+    /**
+     * http status: 200 AND result: FAIL
+     * 시스템은 이슈 없고, 비즈니스 로직 처리에서 에러가 발생함
+     *
+     * @param e
+     * @return
+     */
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    @ExceptionHandler(value = BaseException.class)
+    public CommonResponse onBaseException(BaseException e) {
+        String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+        if (SPECIFIC_ALERT_TARGET_ERROR_CODE_LIST.contains(e.getErrorCode())) {
+            log.error("[BaseException] eventId = {}, cause = {}, errorMsg = {}",
+                    eventId,
+                    NestedExceptionUtils.getMostSpecificCause(e),
+                    NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        } else {
+            log.warn("[BaseException] eventId = {}, cause = {}, errorMsg = {}",
+                    eventId,
+                    NestedExceptionUtils.getMostSpecificCause(e),
+                    NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        }
+        return CommonResponse.fail(e.getMessage(), e.getErrorCode().name());
+    }
+
+}

--- a/src/main/java/com/brogs/crm/common/response/CommonResponse.java
+++ b/src/main/java/com/brogs/crm/common/response/CommonResponse.java
@@ -1,0 +1,53 @@
+package com.brogs.crm.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponse<T> {
+
+    private Result result;
+    private T data;
+    private String message;
+    private String errorCode;
+
+    public static <T> CommonResponse<T> success(T data, String message){
+        return (CommonResponse<T>) CommonResponse.builder()
+                .result(Result.SUCCESS)
+                .data(data)
+                .message(message)
+                .build();
+    }
+
+    public static <T> CommonResponse<T> success(T data) {
+        return success(data, null);
+    }
+
+    public static CommonResponse fail(String message, String errorCode) {
+        return CommonResponse.builder()
+                .result(Result.FAIL)
+                .message(message)
+                .errorCode(errorCode)
+                .build();
+    }
+
+    public static CommonResponse fail(ErrorCode errorCode) {
+
+        return CommonResponse.builder()
+                .result(Result.FAIL)
+                .message(errorCode.getErrorMsg())
+                .errorCode(errorCode.name())
+                .build();
+    }
+
+    public enum Result {
+        SUCCESS, FAIL
+    }
+}

--- a/src/main/java/com/brogs/crm/common/response/ErrorCode.java
+++ b/src/main/java/com/brogs/crm/common/response/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.brogs.crm.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    COMMON_SYSTEM_ERROR("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다."),
+    COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
+    COMMON_ILLEGAL_STATUS("잘못된 상태값입니다."),
+
+    // AgentAccount
+    ALREADY_EXISTENT_ACCOUNT("이미 존재하는 계정입니다"),
+    INVALID_CREDENTIALS("유효한 인증이 아닙니다."),
+    EXPIRED_ACCESS_TOKEN("액세스 토큰이 만료되었습니다."),
+    EXPIRED_REFRESH_TOKEN("갱신 토큰이 만료되었습니다.");
+
+    private final String errorMsg;
+
+    public String getErrorMsg(Object... arg) {
+        return String.format(errorMsg, arg);
+    }
+}


### PR DESCRIPTION
응답은 json 형태로 할 것이며, 필드는 result data message errorCode 를 가지고 있다.

응답은 성공과 실패 모두 기본적으로 status 200을 반환할 것이다. 비즈니스 로직상 예상가능한 에러는 시스템 내부 에러가 아닌 유저가 서비스를 사용하는 중에 발생된 Exception이기 때문에 status 200으로 반환해도 된다고 생각한다.

이러한 Exception들은 BaseException를 상속받아 구현한 Exception으로 throw 할것이다. BaseException들은 @ControllerAdvice에서 일괄적으로 처리할 것이다. @ControllerAdvice의 범위는 필터전까지이므로 필터에서 발생한 Exception은 따로 처리해야할 것이다
This closes #22